### PR TITLE
commented out RewriteBase

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,11 +1,9 @@
 RewriteEngine On
 
 RewriteCond %{HTTP_HOST} !localhost
-RewriteBase /bibletool
 RewriteRule ^$ "http\:\/\/bibletool\.konline\.org\/browse\/" [R=301,L]
 
 RewriteCond %{HTTP_HOST} !localhost
-RewriteBase /
 RewriteRule ^bibletool\/? "http\:\/\/bibletool\.konline\.org\/browse\/" [R=301,L]
 
 RewriteRule ^static/([^/]+) index.php?action=static&page=$1 [L]


### PR DESCRIPTION
Hey.. I need to comment out the two RewriteBase rules for my localhost sandbox to work. WIth these two lines, my localhost still gets redirected to konline.org or to localhost/ (without my webroot in the URL).

I briefly tried the change on the server and it seems to work. Please test the change and pull into master if it works.

Thanks,
Jung
